### PR TITLE
feat: add sorting functionality for inline styles in non-css files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 out
 dist
 node_modules
+.DS_Store
 .vscode-test/
 .vscode-test-web/
 *.vsix
-sample.css
 *.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,21 @@
 # Change Log
 
-All notable changes to the "css-sort" extension will be documented in this file.
+## 0.1.0 (2025-05-04)
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+- Added support for sorting CSS properties inside `<style>` tags in HTML, Vue, Svelte, and Astro files ([#2](https://github.com/piyushsarkar/vscode-css-property-sorter/pull/2))
 
-## [0.0.1]
-
-- Initial release
-
-## [0.0.2]
-
-- Bug fixes
-
-## [0.0.3]
-
-- Bug fixes
-
-## [0.0.4]
+## 0.0.4 (2024-12-24)
 
 - Added support for new CSS properties
+
+## 0.0.3 (2023-06-29)
+
+- Minor bug fixes
+
+## 0.0.2 (2023-06-23)
+
+- Fixed initial release issues
+
+## 0.0.1 (2023-06-04)
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sort CSS
 
-This extension allows you to sort css properties in your CSS, SCSS and LESS files.
+This extension allows you to sort css properties in your CSS, SCSS, LESS files, as well as inside `<style>` tags in HTML, Vue, Svelte and Astro files.
 
 ## Features
 
@@ -16,7 +16,7 @@ Shortcut on MacOs: `option` + `s` and on Windows/Linux: `alt` + `s`
 
 ### Sort On Save
 
-This will sort the file whenever you save a css/scss/less file.
+This will sort the file whenever you save a css/scss/less file or any HTML/Vue/Svelte/Astro file containing style tags.
 ![Sort On Save](images/sort_on_save.gif)
 
 ### Sort Selection
@@ -31,3 +31,12 @@ This extension contributes the following settings:
 - `sortcss.sortingStrategy`: Choose sorting strategy from `concentric-css`, `alphabetical`, `smacss` or `manual` (default: `concentric-css`).
 - `sortcss.ignoredFiles`: Ignore files or path. Example: `[ 'sample.css', 'src' ]`
 - `sortcss.manualOrder`: Manual CSS sorting order. (set sortcss.sortingStrategy to `manual` to use this setting)
+
+## Supported File Types
+
+- CSS (.css)
+- SCSS (.scss)
+- LESS (.less)
+- HTML (.html) - CSS within `<style>` tags
+- Vue (.vue) - CSS within `<style>` tags
+- Svelte (.svelte) - CSS within `<style>` tags

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "publisher": "piyushsarkar",
   "author": "Piyush Sarkar",
   "license": "MIT",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/piyushsarkar/vscode-css-property-sorter.git"
   },
   "engines": {
-    "vscode": "^1.97.0"
+    "vscode": "^1.98.0"
   },
   "categories": [
     "Other"
@@ -20,7 +20,11 @@
     "onLanguage:css",
     "onLanguage:scss",
     "onLanguage:sass",
-    "onLanguage:less"
+    "onLanguage:less",
+    "onLanguage:html",
+    "onLanguage:vue",
+    "onLanguage:svelte",
+    "onLanguage:astro"
   ],
   "icon": "images/icon.png",
   "type": "module",
@@ -57,7 +61,7 @@
       {
         "key": "Alt+s",
         "command": "sortcss.run",
-        "when": "editorLangId == 'css' || editorLangId == 'scss' || editorLangId == 'less'"
+        "when": "editorLangId == 'css' || editorLangId == 'scss' || editorLangId == 'less' || editorLangId == 'html' || editorLangId == 'vue' || editorLangId == 'svelte' || editorLangId == 'astro'"
       }
     ],
     "configuration": {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,10 +1,8 @@
-import cssDeclarationSorter from "css-declaration-sorter";
-import postcss from "postcss";
-import * as postcssLess from "postcss-less";
-import * as postcssScss from "postcss-scss";
 import type { Selection, TextDocumentWillSaveEvent, TextEditor } from "vscode";
 import { Range, window } from "vscode";
-import { getConfig, setConfig } from "./config";
+import { findStyleTagRanges, getStyleLangFromSelection } from "./utils";
+import { getConfig, setConfig, supportedNonCssFiles, supportedLanguages } from "./config";
+import { sorter, type SortOrder } from "./sorter";
 
 export const sortCss = async (textEditor: TextEditor) => {
   const currentFile = textEditor.document;
@@ -12,12 +10,6 @@ export const sortCss = async (textEditor: TextEditor) => {
   /* check for ignored files and return if found */
   const ignoredFiles: string[] = getConfig("ignoredFiles") || [];
   if (ignoredFiles.some((val) => textEditor.document.uri.path.includes(val))) return;
-  const syntax =
-    currentFile.languageId === "scss" || currentFile.languageId === "sass"
-      ? postcssScss
-      : currentFile.languageId === "less"
-        ? postcssLess
-        : undefined;
 
   const manualOrder: string[] = getConfig("manualOrder") || [];
   const manualOrderCompareFunction = (a: string, b: string) =>
@@ -26,10 +18,13 @@ export const sortCss = async (textEditor: TextEditor) => {
   const order =
     getConfig("sortingStrategy") === "manual"
       ? manualOrderCompareFunction
-      : getConfig<"alphabetical" | "concentric-css" | "smacss">("sortingStrategy");
+      : getConfig<SortOrder>("sortingStrategy");
 
   let selection: Selection | Range = textEditor.selection;
-  if (selection.isEmpty) {
+  const isFullDocument = selection.isEmpty;
+  const isNonCssFile = supportedNonCssFiles.has(currentFile.languageId);
+
+  if (isFullDocument) {
     selection = new Range(
       currentFile.lineAt(0).range.start,
       currentFile.lineAt(currentFile.lineCount - 1).range.end,
@@ -37,24 +32,42 @@ export const sortCss = async (textEditor: TextEditor) => {
   }
 
   const text = currentFile.getText(selection);
-  const sortedOutput = await postcss([cssDeclarationSorter({ order })])
-    .process(text, { from: undefined, syntax })
-    .then((result) => result.css)
-    .catch(() => {
-      return text;
-    });
+  let sortedOutput = text;
 
-  if (sortedOutput === text) {
-    return;
+  if (isFullDocument && isNonCssFile) {
+    const styleTagRanges = findStyleTagRanges(text);
+    if (styleTagRanges.length === 0) return;
+
+    const results = await Promise.all(
+      styleTagRanges.map((range) => {
+        const textInRange = text.slice(range.start, range.end);
+        return sorter(textInRange, order, range.lang, range);
+      }),
+    );
+
+    results.forEach((result) => {
+      const { output, range, originalOutput } = result;
+      if (range && output !== originalOutput) {
+        sortedOutput = sortedOutput.slice(0, range.start) + output + sortedOutput.slice(range.end);
+      }
+    });
+  } else {
+    const language = isNonCssFile
+      ? getStyleLangFromSelection(currentFile, selection)
+      : currentFile.languageId;
+    const { output } = await sorter(text, order, language);
+    sortedOutput = output;
   }
 
-  textEditor.edit((editBuilder) => {
-    editBuilder.replace(selection, sortedOutput);
-  });
+  if (sortedOutput !== text) {
+    textEditor.edit((editBuilder) => {
+      editBuilder.replace(selection, sortedOutput);
+    });
+  }
 };
 
 export const sortOnSave = (e: TextDocumentWillSaveEvent) => {
-  if (getConfig("sortOnSave") && ["css", "less", "scss"].includes(e.document.languageId)) {
+  if (getConfig("sortOnSave") && supportedLanguages.has(e.document.languageId)) {
     const editor = window.activeTextEditor;
     if (editor) {
       sortCss(editor);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,8 @@
 import { workspace } from "vscode";
 
+export const supportedNonCssFiles = new Set(["html", "vue", "svelte", "astro"]);
+export const supportedLanguages = new Set(["scss", "sass", "less", ...supportedNonCssFiles]);
+
 export const getConfig = <T>(section: string): T | undefined => {
   return workspace.getConfiguration("sortcss").get(section);
 };

--- a/src/sorter.ts
+++ b/src/sorter.ts
@@ -1,0 +1,46 @@
+import cssDeclarationSorter from "css-declaration-sorter";
+import postcss from "postcss";
+import * as postcssLess from "postcss-less";
+import * as postcssScss from "postcss-scss";
+
+export type SortOrder = "alphabetical" | "concentric-css" | "smacss";
+type SortFunction = (propertyNameA: string, propertyNameB: string) => -1 | 0 | 1;
+
+export const getPostcssSyntax = (languageId?: string) => {
+  switch (languageId) {
+    case "scss":
+    case "sass":
+      return postcssScss;
+    case "less":
+      return postcssLess;
+    default:
+      return undefined;
+  }
+};
+
+export const sorter = async (
+  text: string,
+  order: SortOrder | SortFunction | undefined,
+  language: string | undefined,
+  range?: { start: number; end: number },
+) => {
+  try {
+    const syntax = getPostcssSyntax(language);
+    const { css } = await postcss([cssDeclarationSorter({ order })]).process(text, {
+      from: undefined,
+      syntax,
+    });
+    return {
+      output: css,
+      originalOutput: text,
+      range,
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      output: text,
+      originalOutput: text,
+      range,
+    };
+  }
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,42 @@
+import { type Range, type Selection, type TextDocument } from "vscode";
+import { supportedNonCssFiles } from "./config";
+
+type StyleTagInfo = {
+  start: number;
+  end: number;
+  lang?: string;
+};
+
+export const findStyleTagRanges = (text: string): StyleTagInfo[] => {
+  const ranges: StyleTagInfo[] = [];
+  const styleTagRegex = /<style([^>]*?)>([\s\S]*?)<\/style>/g;
+  let match;
+
+  while ((match = styleTagRegex.exec(text)) !== null) {
+    const attributes = match[1];
+    const langMatch = attributes.match(/lang=["']([^"']+)["']/);
+    ranges.push({
+      start: match.index + match[0].indexOf(">") + 1,
+      end: match.index + match[0].length - "</style>".length,
+      lang: langMatch ? langMatch[1] : undefined,
+    });
+  }
+
+  return ranges.reverse();
+};
+
+export const getStyleLangFromSelection = (
+  textDocument: TextDocument,
+  selection?: Selection | Range,
+) => {
+  if (supportedNonCssFiles.has(textDocument.languageId)) {
+    if (selection && !selection.isEmpty) {
+      const selectionStart = textDocument.offsetAt(selection.start);
+      const styleRanges = findStyleTagRanges(textDocument.getText());
+      const styleTag = styleRanges.find(
+        (range) => selectionStart >= range.start && selectionStart <= range.end,
+      );
+      return styleTag?.lang;
+    }
+  }
+};


### PR DESCRIPTION
Resolves #1

## Overview

This pull request extends the CSS property sorting functionality to handle inline styles inside <style> tags within non-css files, including: html, svelte, vue and astro

### Usage

> [!NOTE] 
> There is no change in how the extension works. It will automatically detect non-css files and sort the css properties inside the `<style>` tags using the same rules as before.

- Press `Alt+S` (Windows/Linux) or `Option+S` (macOS) to sort manually
- Enable sort on save by setting the following in VSCode:
  ```json
  "sortcss.sortOnSave": true
  ```
